### PR TITLE
MerkleApiClient -> Warpcast rebrand

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ poetry add farcaster
 
 ## Usage
 
-This SDK leverages the Warpcast API. [Warpcast](https://warpcast.com/) is one of many Farcaster clients. As more clients and APIs are created, these will be added to the SDK.
+This SDK leverages the Warpcast API. [Warpcast](https://warpcast.com/) is one of many Farcaster [clients](https://github.com/a16z/awesome-farcaster#clients). As more APIs are created and hosted by different clients, these will be added to the SDK.
 
 To use the Warpcast API you need to have a Farcaster account. We will use the mnemonic or private key of the Farcaster custody account (not your main wallet) to connect to the API.
 

--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ Next, save your Farcaster mnemonic or private key to a `.env` file. Now you can 
 
 ```python
 import os
-from farcaster import MerkleApiClient
+from farcaster import Warpcast
 from dotenv import load_dotenv
 
 load_dotenv()
 
-client = MerkleApiClient(mnemonic=os.environ.get("<MNEMONIC_ENV_VAR>"))
+client = Warpcast(mnemonic=os.environ.get("<MNEMONIC_ENV_VAR>"))
 
 print(client.get_healthcheck())
 ```

--- a/README.md
+++ b/README.md
@@ -56,35 +56,35 @@ print(client.get_healthcheck())
 Get a cast
 
 ```python
-response = fcc.get_cast("0x321712dc8eccc5d2be38e38c1ef0c8916c49949a80ffe20ec5752bb23ea4d86f")
+response = client.get_cast("0x321712dc8eccc5d2be38e38c1ef0c8916c49949a80ffe20ec5752bb23ea4d86f")
 print(response.cast.author.username) # "dwr"
 ```
 
 Publish a cast
 
 ```python
-response = fcc.post_cast(text="Hello world!")
+response = client.post_cast(text="Hello world!")
 print(response.cast.hash) # "0x...."
 ```
 
 Get a user by username
 
 ```python
-user = fcc.get_user_by_username("mason")
+user = client.get_user_by_username("mason")
 print(user.username) # "mason"
 ```
 
 Get a user's followers using a fid (farcaster ID)
 
 ```python
-response = fcc.get_followers(fid=50)
+response = client.get_followers(fid=50)
 print(response.users) # [user1, user2, user3]
 ```
 
 Stream recent casts
 
 ```python
-for cast in fcc.stream_casts():
+for cast in client.stream_casts():
     if cast:
         print(cast.text) # "Hello world!"
 ```
@@ -92,21 +92,21 @@ for cast in fcc.stream_casts():
 Get users who recently joined Farcaster
 
 ```python
-response = fcc.get_recent_users()
+response = client.get_recent_users()
 print(response.users) # [user1, user2, user3]
 ```
 
 Get your own user object
 
 ```python
-user = fcc.get_me()
+user = client.get_me()
 print(user.username) # "you"
 ```
 
 Recast a cast
 
 ```python
-response = fcc.recast("0x....")
+response = client.recast("0x....")
 print(response.cast.hash) # "0x...."
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,14 +33,11 @@ poetry add farcaster
 
 ## Usage
 
-To use the Farcaster API you need to have a Farcaster account. We will use the mnemonic or private key of the Farcaster custody account (not your main wallet) to connect to the API.
+This SDK leverages the Warpcast API. [Warpcast](https://warpcast.com/) is one of many Farcaster clients. As more clients and APIs are created, these will be added to the SDK.
 
-First install dotenv:
+To use the Warpcast API you need to have a Farcaster account. We will use the mnemonic or private key of the Farcaster custody account (not your main wallet) to connect to the API.
 
-```bash
-pip install python-dotenv # Or 'poetry add python-dotenv'
-```
-Next, save your Farcaster mnemonic or private key to a `.env` file. Now you can initialize the client, and automatically connect to the Farcaster API!
+First, save your Farcaster mnemonic or private key to a `.env` file. Now you can initialize the client, and automatically connect to the Farcaster API!
 
 ```python
 import os

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,13 +16,11 @@ poetry add farcaster
 
 
 ## Usage
-To use the Farcaster API you need to have a Farcaster account. We will use the mnemonic or private key of the Farcaster custody account (not your main wallet) to connect to the API.
+This SDK leverages the Warpcast API. [Warpcast](https://warpcast.com/) is one of many Farcaster clients. As more clients and APIs are created, these will be added to the SDK.
 
-First install dotenv:
-```bash
-pip install python-dotenv # Or 'poetry add python-dotenv'
-```
-Next, save your Farcaster mnemonic or private key to a `.env` file. Now you can initialize the client, and automatically connect to the Farcaster API!
+To use the Warpcast API you need to have a Farcaster account. We will use the mnemonic or private key of the Farcaster custody account (not your main wallet) to connect to the API.
+
+First, save your Farcaster mnemonic or private key to a `.env` file. Now you can initialize the client, and automatically connect to the Farcaster API!
 
 ```python
 import os

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,12 +26,12 @@ Next, save your Farcaster mnemonic or private key to a `.env` file. Now you can 
 
 ```python
 import os
-from farcaster import MerkleApiClient
+from farcaster import Warpcast
 from dotenv import load_dotenv
 
 load_dotenv()
 
-client = MerkleApiClient(mnemonic=os.environ.get("<MNEMONIC_ENV_VAR>"))
+client = Warpcast(mnemonic=os.environ.get("<MNEMONIC_ENV_VAR>"))
 
 print(client.get_healthcheck())
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,8 @@ poetry add farcaster
 
 
 ## Usage
-This SDK leverages the Warpcast API. [Warpcast](https://warpcast.com/) is one of many Farcaster clients. As more clients and APIs are created, these will be added to the SDK.
+
+This SDK leverages the Warpcast API. [Warpcast](https://warpcast.com/) is one of many Farcaster [clients](https://github.com/a16z/awesome-farcaster#clients). As more APIs are created and hosted by different clients, these will be added to the SDK.
 
 To use the Warpcast API you need to have a Farcaster account. We will use the mnemonic or private key of the Farcaster custody account (not your main wallet) to connect to the API.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,35 +40,35 @@ print(client.get_healthcheck())
 Get a cast
 
 ```python
-response = fcc.get_cast("0x321712dc8eccc5d2be38e38c1ef0c8916c49949a80ffe20ec5752bb23ea4d86f")
+response = client.get_cast("0x321712dc8eccc5d2be38e38c1ef0c8916c49949a80ffe20ec5752bb23ea4d86f")
 print(response.cast.author.username) # "dwr"
 ```
 
 Publish a cast
 
 ```python
-response = fcc.post_cast(text="Hello world!")
+response = client.post_cast(text="Hello world!")
 print(response.cast.hash) # "0x...."
 ```
 
 Get a user by username
 
 ```python
-user = fcc.get_user_by_username("mason")
+user = client.get_user_by_username("mason")
 print(user.username) # "mason"
 ```
 
 Get a user's followers using a fid (farcaster ID)
 
 ```python
-response = fcc.get_followers(fid=50)
+response = client.get_followers(fid=50)
 print(response.users) # [user1, user2, user3]
 ```
 
 Stream recent casts
 
 ```python
-for cast in fcc.stream_casts():
+for cast in client.stream_casts():
     if cast:
         print(cast.text) # "Hello world!"
 ```
@@ -76,21 +76,21 @@ for cast in fcc.stream_casts():
 Get users who recently joined Farcaster
 
 ```python
-response = fcc.get_recent_users()
+response = client.get_recent_users()
 print(response.users) # [user1, user2, user3]
 ```
 
 Get your own user object
 
 ```python
-user = fcc.get_me()
+user = client.get_me()
 print(user.username) # "you"
 ```
 
 Recast a cast
 
 ```python
-response = fcc.recast("0x....")
+response = client.recast("0x....")
 print(response.cast.hash) # "0x...."
 ```
 

--- a/farcaster/__init__.py
+++ b/farcaster/__init__.py
@@ -2,7 +2,7 @@
 
 import sys
 
-from .client import MerkleApiClient  # noqa
+from .client import Warpcast  # noqa
 
 if sys.version_info >= (3, 8):
     from importlib import metadata as importlib_metadata

--- a/farcaster/client.py
+++ b/farcaster/client.py
@@ -19,8 +19,8 @@ from farcaster.models import *
 from farcaster.utils.stream_generator import stream_generator
 
 
-class MerkleApiClient:
-    """The MerkleApiClient class is a wrapper around the Farcaster API.
+class Warpcast:
+    """The Warpcast class is a wrapper around the Farcaster API.
     It also provides a number of helpful methods and utilities for interacting with the protocol.
     Pydantic models are used under the hood to validate the data returned from the API.
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,15 +3,15 @@ import os
 import pytest
 from dotenv import load_dotenv
 
-from farcaster.client import MerkleApiClient
+from farcaster.client import Warpcast
 
 
 @pytest.fixture(scope="session", autouse=True)
-def fcc() -> MerkleApiClient:
+def fcc() -> Warpcast:
     load_dotenv()
     access_token = os.getenv("AUTH")
     assert access_token, "AUTH env var not set"
-    return MerkleApiClient(access_token=access_token)
+    return Warpcast(access_token=access_token)
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from farcaster.client import Warpcast
 
 
 @pytest.fixture(scope="session", autouse=True)
-def fcc() -> Warpcast:
+def client() -> Warpcast:
     load_dotenv()
     access_token = os.getenv("AUTH")
     assert access_token, "AUTH env var not set"

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -6,61 +6,61 @@ from dotenv import load_dotenv
 from farcaster.client import Warpcast
 
 
-def fcc_from_mnemonic() -> None:
+def client_from_mnemonic() -> None:
     load_dotenv()
     MNEMONIC = os.getenv("MNEMONIC")
     assert MNEMONIC, "MNEMONIC env var not set"
-    fcc = Warpcast(mnemonic=MNEMONIC, rotation_duration=200)
-    assert fcc.wallet
-    assert fcc.get_user_by_username("mason").username == "mason"
-    assert fcc.access_token
-    assert fcc.rotation_duration == 200
-    print(fcc.access_token)
-    print(fcc.get_me())
+    client = Warpcast(mnemonic=MNEMONIC, rotation_duration=200)
+    assert client.wallet
+    assert client.get_user_by_username("mason").username == "mason"
+    assert client.access_token
+    assert client.rotation_duration == 200
+    print(client.access_token)
+    print(client.get_me())
 
 
-def fcc_from_pkey() -> None:
+def client_from_pkey() -> None:
     load_dotenv()
     PKEY = os.getenv("PKEY")
     assert PKEY, "PKEY env var not set"
-    fcc = Warpcast(private_key=PKEY)
+    client = Warpcast(private_key=PKEY)
     expiry = (int(time.time()) + (10 * 60)) * 1000
-    assert fcc.wallet
-    assert fcc.get_user_by_username("mason").username == "mason"
-    assert fcc.access_token
-    assert fcc.rotation_duration == 10
-    print(fcc.expires_at)
-    print(fcc.access_token)
-    assert fcc.expires_at == expiry
+    assert client.wallet
+    assert client.get_user_by_username("mason").username == "mason"
+    assert client.access_token
+    assert client.rotation_duration == 10
+    print(client.expires_at)
+    print(client.access_token)
+    assert client.expires_at == expiry
 
 
-def fcc_from_auth() -> Warpcast:
+def client_from_auth() -> Warpcast:
     load_dotenv()
     AUTH = os.getenv("AUTH")
     assert AUTH, "AUTH env var not set"
-    fcc = Warpcast(access_token=AUTH)
-    fid = fcc.get_user_by_username("apitest").fid
-    first_cast = fcc.get_casts(fid=fid).casts[-1]
-    me = fcc.get_me()
+    client = Warpcast(access_token=AUTH)
+    fid = client.get_user_by_username("apitest").fid
+    first_cast = client.get_casts(fid=fid).casts[-1]
+    me = client.get_me()
     print(me)
     print(first_cast.hash)
-    print(fcc.access_token)
-    return fcc
+    print(client.access_token)
+    return client
 
 
 def test_rotation() -> None:
     load_dotenv()
     PKEY = os.getenv("PKEY")
-    fcc = Warpcast(private_key=PKEY, rotation_duration=1)
+    client = Warpcast(private_key=PKEY, rotation_duration=1)
     expiry = (int(time.time()) + (60)) * 1000
     while True:
-        assert fcc.wallet
-        assert fcc.get_user_by_username("mason").username == "mason"
-        assert fcc.access_token
-        print(fcc.access_token)
-        print(fcc.expires_at)
+        assert client.wallet
+        assert client.get_user_by_username("mason").username == "mason"
+        assert client.access_token
+        print(client.access_token)
+        print(client.expires_at)
         print(expiry)
-        print(fcc.rotation_duration)
+        print(client.rotation_duration)
         time.sleep(25)
 
 
@@ -68,12 +68,12 @@ def test_stream_casts() -> None:
     load_dotenv()
     MNEMONIC = os.getenv("MNEMONIC")
     assert MNEMONIC, "MNEMONIC env var not set"
-    fcc = Warpcast(mnemonic=MNEMONIC)
-    print(fcc.access_token)
+    client = Warpcast(mnemonic=MNEMONIC)
+    print(client.access_token)
     # fid = 50
-    # all_following = fcc.get_all_following(fid=fid)
+    # all_following = client.get_all_following(fid=fid)
     # print(len(all_following.users))
-    for cast in fcc.stream_casts():
+    for cast in client.stream_casts():
         if cast:
             print(cast.hash)
 
@@ -82,9 +82,9 @@ def test_stream_users() -> None:
     load_dotenv()
     MNEMONIC = os.getenv("MNEMONIC")
     assert MNEMONIC, "MNEMONIC env var not set"
-    fcc = Warpcast(mnemonic=MNEMONIC)
-    print(fcc.access_token)
-    for user in fcc.stream_users():
+    client = Warpcast(mnemonic=MNEMONIC)
+    print(client.access_token)
+    for user in client.stream_users():
         if user:
             print(user.dict())
 
@@ -93,9 +93,9 @@ def test_stream_notifications() -> None:
     load_dotenv()
     MNEMONIC = os.getenv("MNEMONIC")
     assert MNEMONIC, "MNEMONIC env var not set"
-    fcc = Warpcast(mnemonic=MNEMONIC)
-    print(fcc.access_token)
-    for notification in fcc.stream_notifications():
+    client = Warpcast(mnemonic=MNEMONIC)
+    print(client.access_token)
+    for notification in client.stream_notifications():
         if notification:
             print(notification.id)
         if notification:

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -3,14 +3,14 @@ import time
 
 from dotenv import load_dotenv
 
-from farcaster.client import MerkleApiClient
+from farcaster.client import Warpcast
 
 
 def fcc_from_mnemonic() -> None:
     load_dotenv()
     MNEMONIC = os.getenv("MNEMONIC")
     assert MNEMONIC, "MNEMONIC env var not set"
-    fcc = MerkleApiClient(mnemonic=MNEMONIC, rotation_duration=200)
+    fcc = Warpcast(mnemonic=MNEMONIC, rotation_duration=200)
     assert fcc.wallet
     assert fcc.get_user_by_username("mason").username == "mason"
     assert fcc.access_token
@@ -23,7 +23,7 @@ def fcc_from_pkey() -> None:
     load_dotenv()
     PKEY = os.getenv("PKEY")
     assert PKEY, "PKEY env var not set"
-    fcc = MerkleApiClient(private_key=PKEY)
+    fcc = Warpcast(private_key=PKEY)
     expiry = (int(time.time()) + (10 * 60)) * 1000
     assert fcc.wallet
     assert fcc.get_user_by_username("mason").username == "mason"
@@ -34,11 +34,11 @@ def fcc_from_pkey() -> None:
     assert fcc.expires_at == expiry
 
 
-def fcc_from_auth() -> MerkleApiClient:
+def fcc_from_auth() -> Warpcast:
     load_dotenv()
     AUTH = os.getenv("AUTH")
     assert AUTH, "AUTH env var not set"
-    fcc = MerkleApiClient(access_token=AUTH)
+    fcc = Warpcast(access_token=AUTH)
     fid = fcc.get_user_by_username("apitest").fid
     first_cast = fcc.get_casts(fid=fid).casts[-1]
     me = fcc.get_me()
@@ -51,7 +51,7 @@ def fcc_from_auth() -> MerkleApiClient:
 def test_rotation() -> None:
     load_dotenv()
     PKEY = os.getenv("PKEY")
-    fcc = MerkleApiClient(private_key=PKEY, rotation_duration=1)
+    fcc = Warpcast(private_key=PKEY, rotation_duration=1)
     expiry = (int(time.time()) + (60)) * 1000
     while True:
         assert fcc.wallet
@@ -68,7 +68,7 @@ def test_stream_casts() -> None:
     load_dotenv()
     MNEMONIC = os.getenv("MNEMONIC")
     assert MNEMONIC, "MNEMONIC env var not set"
-    fcc = MerkleApiClient(mnemonic=MNEMONIC)
+    fcc = Warpcast(mnemonic=MNEMONIC)
     print(fcc.access_token)
     # fid = 50
     # all_following = fcc.get_all_following(fid=fid)
@@ -82,7 +82,7 @@ def test_stream_users() -> None:
     load_dotenv()
     MNEMONIC = os.getenv("MNEMONIC")
     assert MNEMONIC, "MNEMONIC env var not set"
-    fcc = MerkleApiClient(mnemonic=MNEMONIC)
+    fcc = Warpcast(mnemonic=MNEMONIC)
     print(fcc.access_token)
     for user in fcc.stream_users():
         if user:
@@ -93,7 +93,7 @@ def test_stream_notifications() -> None:
     load_dotenv()
     MNEMONIC = os.getenv("MNEMONIC")
     assert MNEMONIC, "MNEMONIC env var not set"
-    fcc = MerkleApiClient(mnemonic=MNEMONIC)
+    fcc = Warpcast(mnemonic=MNEMONIC)
     print(fcc.access_token)
     for notification in fcc.stream_notifications():
         if notification:

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -5,7 +5,7 @@ import time
 import pytest
 import requests
 
-from farcaster.client import MerkleApiClient, now_ms
+from farcaster.client import Warpcast, now_ms
 from farcaster.models import *
 
 
@@ -35,7 +35,7 @@ class MockResponsePut:
 
 
 @pytest.mark.vcr
-def test_auth_params(fcc: MerkleApiClient) -> None:
+def test_auth_params(fcc: Warpcast) -> None:
     """Unit test that tests auth params model
 
     Args:
@@ -56,7 +56,7 @@ def test_now_ms() -> None:
 
 
 @pytest.mark.vcr
-def test_create_new_auth_token_no_wallet(fcc: MerkleApiClient) -> None:
+def test_create_new_auth_token_no_wallet(fcc: Warpcast) -> None:
     """Unit test that puts auth
 
     Args:
@@ -70,7 +70,7 @@ def test_create_new_auth_token_no_wallet(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_delete_auth(monkeypatch: Any, fcc: MerkleApiClient) -> None:
+def test_delete_auth(monkeypatch: Any, fcc: Warpcast) -> None:
     """Unit test that deletes auth
 
     Args:
@@ -91,7 +91,7 @@ def test_delete_auth(monkeypatch: Any, fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_put_auth(monkeypatch: Any, fcc: MerkleApiClient) -> None:
+def test_put_auth(monkeypatch: Any, fcc: Warpcast) -> None:
     """Unit test that test put auth
 
     Args:
@@ -109,7 +109,7 @@ def test_put_auth(monkeypatch: Any, fcc: MerkleApiClient) -> None:
         return "eip191:V5Opo6K5M6JECBNurxHDtbts3Uqh/QpisEwm0ZSPqQdXrnTBvBZDZSME3HPeq/1pGP7ISwKJocGeWZESMxxxxxx"
 
     monkeypatch.setattr(requests, "put", mock_put)
-    monkeypatch.setattr(MerkleApiClient, "generate_custody_auth_header", mock_header)
+    monkeypatch.setattr(Warpcast, "generate_custody_auth_header", mock_header)
 
     now = int(time.time())
     obj = {"timestamp": now * 1000, "expiresAt": int(now + 600) * 1000}

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -35,11 +35,11 @@ class MockResponsePut:
 
 
 @pytest.mark.vcr
-def test_auth_params(fcc: Warpcast) -> None:
+def test_auth_params(client: Warpcast) -> None:
     """Unit test that tests auth params model
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
@@ -56,26 +56,26 @@ def test_now_ms() -> None:
 
 
 @pytest.mark.vcr
-def test_create_new_auth_token_no_wallet(fcc: Warpcast) -> None:
+def test_create_new_auth_token_no_wallet(client: Warpcast) -> None:
     """Unit test that puts auth
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
     with pytest.raises(Exception, match="^Wallet not set$"):
-        fcc.create_new_auth_token(expires_in=10)
+        client.create_new_auth_token(expires_in=10)
 
 
 @pytest.mark.vcr
-def test_delete_auth(monkeypatch: Any, fcc: Warpcast) -> None:
+def test_delete_auth(monkeypatch: Any, client: Warpcast) -> None:
     """Unit test that deletes auth
 
     Args:
         monkeypatch: fixture
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
@@ -86,17 +86,17 @@ def test_delete_auth(monkeypatch: Any, fcc: Warpcast) -> None:
 
     monkeypatch.setattr(requests.Session, "delete", mock_delete)
 
-    response = fcc.delete_auth()
+    response = client.delete_auth()
     assert response.success
 
 
 @pytest.mark.vcr
-def test_put_auth(monkeypatch: Any, fcc: Warpcast) -> None:
+def test_put_auth(monkeypatch: Any, client: Warpcast) -> None:
     """Unit test that test put auth
 
     Args:
         monkeypatch: fixture
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
@@ -114,5 +114,5 @@ def test_put_auth(monkeypatch: Any, fcc: Warpcast) -> None:
     now = int(time.time())
     obj = {"timestamp": now * 1000, "expiresAt": int(now + 600) * 1000}
     ap = AuthParams(**obj)
-    response = fcc.put_auth(auth_params=ap)
+    response = client.put_auth(auth_params=ap)
     assert response.token.secret

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,9 @@
 import pytest
 
-from farcaster.client import MerkleApiClient, get_wallet
+from farcaster.client import Warpcast, get_wallet
 
 
-def test_get_base_path(fcc: MerkleApiClient) -> None:
+def test_get_base_path(fcc: Warpcast) -> None:
     """Unit test that gets a user's recent notifications. Has to be the user who owns the access token
 
     Args:
@@ -15,7 +15,7 @@ def test_get_base_path(fcc: MerkleApiClient) -> None:
     assert fcc.get_base_path()
 
 
-def test_get_base_options(fcc: MerkleApiClient) -> None:
+def test_get_base_options(fcc: Warpcast) -> None:
     """Unit test that gets a user's recent notifications. Has to be the user who owns the access token
 
     Args:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,28 +3,28 @@ import pytest
 from farcaster.client import Warpcast, get_wallet
 
 
-def test_get_base_path(fcc: Warpcast) -> None:
+def test_get_base_path(client: Warpcast) -> None:
     """Unit test that gets a user's recent notifications. Has to be the user who owns the access token
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    assert fcc.get_base_path()
+    assert client.get_base_path()
 
 
-def test_get_base_options(fcc: Warpcast) -> None:
+def test_get_base_options(client: Warpcast) -> None:
     """Unit test that gets a user's recent notifications. Has to be the user who owns the access token
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    assert fcc.get_base_options() is None
+    assert client.get_base_options() is None
 
 
 def test_get_wallet() -> None:

--- a/tests/test_farcaster.py
+++ b/tests/test_farcaster.py
@@ -9,28 +9,28 @@ from farcaster.client import Warpcast
 
 
 @pytest.mark.vcr
-def test_get_cast(fcc: Warpcast) -> None:
+def test_get_cast(client: Warpcast) -> None:
     """Unit test that gets cast
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
     # get cast
-    response = fcc.get_cast(
+    response = client.get_cast(
         "0x321712dc8eccc5d2be38e38c1ef0c8916c49949a80ffe20ec5752bb23ea4d86f"
     )
     assert response.cast.author.fid == 3
 
 
 @pytest.mark.vcr
-def test_nonexistent_get_cast(fcc: Warpcast) -> None:
+def test_nonexistent_get_cast(client: Warpcast) -> None:
     """Unit test that gets nonexistent cast
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
@@ -38,22 +38,22 @@ def test_nonexistent_get_cast(fcc: Warpcast) -> None:
     # get cast
     with pytest.raises(Exception):
         # Should raise error
-        fcc.get_cast(
+        client.get_cast(
             "0x321712dc8eccc5d2be38e38c1ef0c8916c49949a80ffe20ec5752bb23ea4d861"
         )
 
 
 @pytest.mark.vcr
-def test_get_all_casts_in_thread(fcc: Warpcast) -> None:
+def test_get_all_casts_in_thread(client: Warpcast) -> None:
     """Unit test that gets all casts in thread
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    response = fcc.get_all_casts_in_thread(
+    response = client.get_all_casts_in_thread(
         "0x321712dc8eccc5d2be38e38c1ef0c8916c49949a80ffe20ec5752bb23ea4d86f"
     )
     print(response)
@@ -61,287 +61,287 @@ def test_get_all_casts_in_thread(fcc: Warpcast) -> None:
 
 
 @pytest.mark.vcr
-def test_get_casts(fcc: Warpcast) -> None:
+def test_get_casts(client: Warpcast) -> None:
     """Unit test that gets a user's recent casts
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    response1 = fcc.get_casts(fid=50)
+    response1 = client.get_casts(fid=50)
     assert len(response1.casts) == 25
-    response2 = fcc.get_casts(fid=50, limit=10)
+    response2 = client.get_casts(fid=50, limit=10)
     assert len(response2.casts) == 10
 
 
 @pytest.mark.vcr
-def test_get_cast_likes(fcc: Warpcast) -> None:
+def test_get_cast_likes(client: Warpcast) -> None:
     """Unit test that gets cast likes
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    response = fcc.get_cast_likes(
+    response = client.get_cast_likes(
         "0x321712dc8eccc5d2be38e38c1ef0c8916c49949a80ffe20ec5752bb23ea4d86f"
     )
     assert response.likes[0].reactor.fid == 43
 
 
 @pytest.mark.vcr
-def test_get_cast_recasters(fcc: Warpcast) -> None:
+def test_get_cast_recasters(client: Warpcast) -> None:
     """Unit test that gets cast recasters
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    response = fcc.get_cast_recasters(
+    response = client.get_cast_recasters(
         "0x321712dc8eccc5d2be38e38c1ef0c8916c49949a80ffe20ec5752bb23ea4d86f"
     )
     assert response.users[0].username == "adrienne"
 
 
 @pytest.mark.vcr
-def test_get_recent_casts(fcc: Warpcast) -> None:
+def test_get_recent_casts(client: Warpcast) -> None:
     """Unit test that gets all recent casts
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    response1 = fcc.get_recent_casts()
+    response1 = client.get_recent_casts()
     assert len(response1.casts) == 100
-    response2 = fcc.get_recent_casts(limit=50)
+    response2 = client.get_recent_casts(limit=50)
     assert len(response2.casts) == 50
 
 
 @pytest.mark.vcr
 @pytest.mark.dependency()
-def test_follow_user(fcc: Warpcast) -> None:
+def test_follow_user(client: Warpcast) -> None:
     """Unit test that follows user
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    fid = fcc.get_user_by_username(username="mmm").fid
-    status = fcc.follow_user(fid=fid)
+    fid = client.get_user_by_username(username="mmm").fid
+    status = client.follow_user(fid=fid)
     assert status.success
 
 
 @pytest.mark.vcr
 @pytest.mark.dependency(depends=["test_follow_user"])
-def test_unfollow_user(fcc: Warpcast) -> None:
+def test_unfollow_user(client: Warpcast) -> None:
     """Unit test that unfollows user
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    fid = fcc.get_user_by_username(username="mmm").fid
-    status = fcc.unfollow_user(fid=fid)
+    fid = client.get_user_by_username(username="mmm").fid
+    status = client.unfollow_user(fid=fid)
     assert status.success
 
 
 @pytest.mark.vcr
-def test_get_followers(fcc: Warpcast) -> None:
+def test_get_followers(client: Warpcast) -> None:
     """Unit test that gets followers
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    response = fcc.get_followers(fid=50)
+    response = client.get_followers(fid=50)
     assert len(response.users) == 25
-    response = fcc.get_followers(fid=50, limit=100)
+    response = client.get_followers(fid=50, limit=100)
     assert len(response.users) == 100
 
 
 @pytest.mark.vcr
-def test_get_following(fcc: Warpcast) -> None:
+def test_get_following(client: Warpcast) -> None:
     """Unit test that gets who a user is following
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    response = fcc.get_following(fid=50)
+    response = client.get_following(fid=50)
     assert len(response.users) == 25
-    response = fcc.get_following(fid=50, limit=100)
+    response = client.get_following(fid=50, limit=100)
     assert len(response.users) == 100
 
 
 @pytest.mark.vcr
-def test_get_all_following(fcc: Warpcast) -> None:
+def test_get_all_following(client: Warpcast) -> None:
     """Unit test that gets everyone who a user is following
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    response = fcc.get_all_following(fid=50)
+    response = client.get_all_following(fid=50)
     assert len(response.users) == 195
 
 
 @pytest.mark.vcr
-def test_get_user(fcc: Warpcast) -> None:
+def test_get_user(client: Warpcast) -> None:
     """Unit test that gets user
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    user = fcc.get_user(fid=50)
+    user = client.get_user(fid=50)
     assert user.username == "mason"
 
 
 @pytest.mark.vcr
-def test_get_user_by_username(fcc: Warpcast) -> None:
+def test_get_user_by_username(client: Warpcast) -> None:
     """Unit test that gets user by username
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    user = fcc.get_user_by_username(username="mason")
+    user = client.get_user_by_username(username="mason")
     assert user.username == "mason"
     assert user.fid == 50
 
 
 @pytest.mark.vcr
-def test_get_user_cast_likes(fcc: Warpcast) -> None:
+def test_get_user_cast_likes(client: Warpcast) -> None:
     """Unit test that gets user cast likes
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    response = fcc.get_user_cast_likes(fid=50)
+    response = client.get_user_cast_likes(fid=50)
     assert len(response.likes) == 25
-    response = fcc.get_user_cast_likes(fid=50, limit=100)
+    response = client.get_user_cast_likes(fid=50, limit=100)
     assert len(response.likes) == 100
 
 
 @pytest.mark.vcr
-def test_get_custody_address(fcc: Warpcast) -> None:
+def test_get_custody_address(client: Warpcast) -> None:
     """Unit test that gets custody address
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    response = fcc.get_custody_address(username="mason")
+    response = client.get_custody_address(username="mason")
     assert response.custody_address == "0x044991055877cb2a6cbce87a34f0d2fd7cb4ad3e"
-    response = fcc.get_custody_address(fid=50)
+    response = client.get_custody_address(fid=50)
     assert response.custody_address == "0x044991055877cb2a6cbce87a34f0d2fd7cb4ad3e"
     with pytest.raises(Exception):
         # Must provide either fname or fid
-        fcc.get_custody_address()
+        client.get_custody_address()
 
 
 @pytest.mark.vcr
-def test_get_me(fcc: Warpcast) -> None:
+def test_get_me(client: Warpcast) -> None:
     """Unit test that gets user
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    user = fcc.get_me()
+    user = client.get_me()
     assert user.username == "apitest"
 
 
 @pytest.mark.vcr
-def test_get_recent_users(fcc: Warpcast) -> None:
+def test_get_recent_users(client: Warpcast) -> None:
     """Unit test that gets recent users
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    response = fcc.get_recent_users()
+    response = client.get_recent_users()
     assert len(response.users) == 25
     assert response.users[0].fid > response.users[1].fid
 
 
 @pytest.mark.vcr
-def test_get_verifications(fcc: Warpcast) -> None:
+def test_get_verifications(client: Warpcast) -> None:
     """Unit test that gets verifications
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    response = fcc.get_verifications(fid=50)
+    response = client.get_verifications(fid=50)
     logging.debug(response)
     assert response.verifications[0].fid == 50
 
 
 @pytest.mark.vcr
-def test_get_user_by_verification(fcc: Warpcast) -> None:
+def test_get_user_by_verification(client: Warpcast) -> None:
     """Unit test that gets user by verification
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
     with pytest.raises(Exception):
-        user = fcc.get_user_by_verification(
+        user = client.get_user_by_verification(
             address="0x000000000877cb2a6cbce87a34f0d2fd7cb4ad3e"
         )
-    user = fcc.get_user_by_verification(
+    user = client.get_user_by_verification(
         address="0xDC40CbF86727093c52582405703e5b97D5C64B66"
     )
     assert user.username == "mason"
 
 
 @pytest.mark.vcr
-def test_stream_casts(fcc: Warpcast) -> None:
+def test_stream_casts(client: Warpcast) -> None:
     """Unit test that tests streaming casts
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
     casts: List[models.ApiCast] = []
-    for cast in fcc.stream_casts(pause_after=-1):
+    for cast in client.stream_casts(pause_after=-1):
         if cast is None:
             break
         casts.append(cast)
@@ -350,32 +350,32 @@ def test_stream_casts(fcc: Warpcast) -> None:
 
 
 @pytest.mark.vcr
-def test_stream_casts_skip_existing(fcc: Warpcast) -> None:
+def test_stream_casts_skip_existing(client: Warpcast) -> None:
     """Unit test that tests streaming casts
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    for cast in fcc.stream_casts(pause_after=-1, skip_existing=True):
+    for cast in client.stream_casts(pause_after=-1, skip_existing=True):
         assert cast is None
         break
 
 
 @pytest.mark.vcr
-def test_stream_users(fcc: Warpcast) -> None:
+def test_stream_users(client: Warpcast) -> None:
     """Unit test that tests streaming users
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
     users: List[models.ApiUser] = []
-    for user in fcc.stream_users(pause_after=-1):
+    for user in client.stream_users(pause_after=-1):
         if user is None:
             break
         users.append(user)
@@ -384,32 +384,32 @@ def test_stream_users(fcc: Warpcast) -> None:
 
 
 @pytest.mark.vcr
-def test_stream_users_skip_existing(fcc: Warpcast) -> None:
+def test_stream_users_skip_existing(client: Warpcast) -> None:
     """Unit test that tests streaming users
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    for user in fcc.stream_users(pause_after=-1, skip_existing=True):
+    for user in client.stream_users(pause_after=-1, skip_existing=True):
         assert user is None
         break
 
 
 @pytest.mark.vcr
-def test_stream_notifications(fcc: Warpcast) -> None:
+def test_stream_notifications(client: Warpcast) -> None:
     """Unit test that tests streaming notifications
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
     notifications: List[Any] = []
-    for notification in fcc.stream_notifications(pause_after=-1):
+    for notification in client.stream_notifications(pause_after=-1):
         if notification is None:
             break
         notifications.append(notification)
@@ -418,16 +418,16 @@ def test_stream_notifications(fcc: Warpcast) -> None:
 
 
 @pytest.mark.vcr
-def test_stream_notifications_skip_existing(fcc: Warpcast) -> None:
+def test_stream_notifications_skip_existing(client: Warpcast) -> None:
     """Unit test that tests streaming notifications
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    for notification in fcc.stream_notifications(pause_after=-1, skip_existing=True):
+    for notification in client.stream_notifications(pause_after=-1, skip_existing=True):
         assert notification is None
         break
 
@@ -439,16 +439,18 @@ class TestRW:
 
     @pytest.mark.vcr
     @pytest.mark.dependency()
-    def test_post_cast(self, fcc: Warpcast) -> None:
+    def test_post_cast(self, client: Warpcast) -> None:
         """Unit test that posts cast
 
         Args:
-            fcc: fixture
+            client: fixture
 
         Returns:
             None
         """
-        response = fcc.post_cast(text="Hello world from our WIP Farcaster Python SDK!")
+        response = client.post_cast(
+            text="Hello world from our WIP Farcaster Python SDK!"
+        )
         logging.debug(response.cast.dict())
         assert response.cast
         self.__class__.cast_hash = response.cast.hash
@@ -456,76 +458,76 @@ class TestRW:
 
     @pytest.mark.vcr
     @pytest.mark.dependency(depends=["TestRW::test_post_cast"])
-    def test_like_cast(self, fcc: Warpcast) -> None:
+    def test_like_cast(self, client: Warpcast) -> None:
         """Unit test that puts cast likes
 
         Args:
-            fcc: fixture
+            client: fixture
 
         Returns:
             None
         """
         assert self.__class__.cast_hash
-        response = fcc.like_cast(self.__class__.cast_hash)
+        response = client.like_cast(self.__class__.cast_hash)
         assert response.like.cast_hash
 
     @pytest.mark.vcr
     @pytest.mark.dependency(depends=["TestRW::test_like_cast"])
-    def test_delete_cast_likes(self, fcc: Warpcast) -> None:
+    def test_delete_cast_likes(self, client: Warpcast) -> None:
         """Unit test that deletes cast likes
 
         Args:
-            fcc: fixture
+            client: fixture
 
         Returns:
             None
         """
         logging.debug(self.__class__.cast_hash)
-        response = fcc.delete_cast_likes(self.__class__.cast_hash)
+        response = client.delete_cast_likes(self.__class__.cast_hash)
         assert response.success
 
     @pytest.mark.vcr
     @pytest.mark.dependency(depends=["TestRW::test_post_cast"])
-    def test_recast(self, fcc: Warpcast) -> None:
+    def test_recast(self, client: Warpcast) -> None:
         """Unit test that recasts cast
 
         Args:
-            fcc: fixture
+            client: fixture
 
         Returns:
             None
         """
-        response = fcc.recast(self.__class__.cast_hash)
+        response = client.recast(self.__class__.cast_hash)
         assert response.cast_hash
 
     @pytest.mark.vcr
     @pytest.mark.dependency(depends=["TestRW::test_recast"])
-    def test_delete_recast(self, fcc: Warpcast) -> None:
+    def test_delete_recast(self, client: Warpcast) -> None:
         """Unit test that deletes recast
 
         Args:
-            fcc: fixture
+            client: fixture
 
         Returns:
             None
         """
         assert self.__class__.cast_hash
         logging.debug(self.__class__.cast_hash)
-        response = fcc.delete_recast(self.__class__.cast_hash)
+        response = client.delete_recast(self.__class__.cast_hash)
         assert response.success
 
     @pytest.mark.vcr
     @pytest.mark.dependency(depends=["TestRW::test_post_cast"])
-    def test_delete_cast(self, fcc: Warpcast) -> None:
+    def test_delete_cast(self, client: Warpcast) -> None:
         """Unit test that deletes cast
 
         Args:
-            fcc: fixture
+            client: fixture
 
         Returns:
             None
         """
         assert self.__class__.cast_hash
         logging.debug(self.__class__.cast_hash)
-        response = fcc.delete_cast(self.__class__.cast_hash)
+        response = client.delete_cast(self.__class__.cast_hash)
         assert response.success

--- a/tests/test_farcaster.py
+++ b/tests/test_farcaster.py
@@ -5,11 +5,11 @@ import logging
 import pytest
 
 from farcaster import models
-from farcaster.client import MerkleApiClient
+from farcaster.client import Warpcast
 
 
 @pytest.mark.vcr
-def test_get_cast(fcc: MerkleApiClient) -> None:
+def test_get_cast(fcc: Warpcast) -> None:
     """Unit test that gets cast
 
     Args:
@@ -26,7 +26,7 @@ def test_get_cast(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_nonexistent_get_cast(fcc: MerkleApiClient) -> None:
+def test_nonexistent_get_cast(fcc: Warpcast) -> None:
     """Unit test that gets nonexistent cast
 
     Args:
@@ -44,7 +44,7 @@ def test_nonexistent_get_cast(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_get_all_casts_in_thread(fcc: MerkleApiClient) -> None:
+def test_get_all_casts_in_thread(fcc: Warpcast) -> None:
     """Unit test that gets all casts in thread
 
     Args:
@@ -61,7 +61,7 @@ def test_get_all_casts_in_thread(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_get_casts(fcc: MerkleApiClient) -> None:
+def test_get_casts(fcc: Warpcast) -> None:
     """Unit test that gets a user's recent casts
 
     Args:
@@ -77,7 +77,7 @@ def test_get_casts(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_get_cast_likes(fcc: MerkleApiClient) -> None:
+def test_get_cast_likes(fcc: Warpcast) -> None:
     """Unit test that gets cast likes
 
     Args:
@@ -93,7 +93,7 @@ def test_get_cast_likes(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_get_cast_recasters(fcc: MerkleApiClient) -> None:
+def test_get_cast_recasters(fcc: Warpcast) -> None:
     """Unit test that gets cast recasters
 
     Args:
@@ -109,7 +109,7 @@ def test_get_cast_recasters(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_get_recent_casts(fcc: MerkleApiClient) -> None:
+def test_get_recent_casts(fcc: Warpcast) -> None:
     """Unit test that gets all recent casts
 
     Args:
@@ -126,7 +126,7 @@ def test_get_recent_casts(fcc: MerkleApiClient) -> None:
 
 @pytest.mark.vcr
 @pytest.mark.dependency()
-def test_follow_user(fcc: MerkleApiClient) -> None:
+def test_follow_user(fcc: Warpcast) -> None:
     """Unit test that follows user
 
     Args:
@@ -142,7 +142,7 @@ def test_follow_user(fcc: MerkleApiClient) -> None:
 
 @pytest.mark.vcr
 @pytest.mark.dependency(depends=["test_follow_user"])
-def test_unfollow_user(fcc: MerkleApiClient) -> None:
+def test_unfollow_user(fcc: Warpcast) -> None:
     """Unit test that unfollows user
 
     Args:
@@ -157,7 +157,7 @@ def test_unfollow_user(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_get_followers(fcc: MerkleApiClient) -> None:
+def test_get_followers(fcc: Warpcast) -> None:
     """Unit test that gets followers
 
     Args:
@@ -173,7 +173,7 @@ def test_get_followers(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_get_following(fcc: MerkleApiClient) -> None:
+def test_get_following(fcc: Warpcast) -> None:
     """Unit test that gets who a user is following
 
     Args:
@@ -189,7 +189,7 @@ def test_get_following(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_get_all_following(fcc: MerkleApiClient) -> None:
+def test_get_all_following(fcc: Warpcast) -> None:
     """Unit test that gets everyone who a user is following
 
     Args:
@@ -203,7 +203,7 @@ def test_get_all_following(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_get_user(fcc: MerkleApiClient) -> None:
+def test_get_user(fcc: Warpcast) -> None:
     """Unit test that gets user
 
     Args:
@@ -217,7 +217,7 @@ def test_get_user(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_get_user_by_username(fcc: MerkleApiClient) -> None:
+def test_get_user_by_username(fcc: Warpcast) -> None:
     """Unit test that gets user by username
 
     Args:
@@ -232,7 +232,7 @@ def test_get_user_by_username(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_get_user_cast_likes(fcc: MerkleApiClient) -> None:
+def test_get_user_cast_likes(fcc: Warpcast) -> None:
     """Unit test that gets user cast likes
 
     Args:
@@ -248,7 +248,7 @@ def test_get_user_cast_likes(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_get_custody_address(fcc: MerkleApiClient) -> None:
+def test_get_custody_address(fcc: Warpcast) -> None:
     """Unit test that gets custody address
 
     Args:
@@ -267,7 +267,7 @@ def test_get_custody_address(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_get_me(fcc: MerkleApiClient) -> None:
+def test_get_me(fcc: Warpcast) -> None:
     """Unit test that gets user
 
     Args:
@@ -281,7 +281,7 @@ def test_get_me(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_get_recent_users(fcc: MerkleApiClient) -> None:
+def test_get_recent_users(fcc: Warpcast) -> None:
     """Unit test that gets recent users
 
     Args:
@@ -296,7 +296,7 @@ def test_get_recent_users(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_get_verifications(fcc: MerkleApiClient) -> None:
+def test_get_verifications(fcc: Warpcast) -> None:
     """Unit test that gets verifications
 
     Args:
@@ -311,7 +311,7 @@ def test_get_verifications(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_get_user_by_verification(fcc: MerkleApiClient) -> None:
+def test_get_user_by_verification(fcc: Warpcast) -> None:
     """Unit test that gets user by verification
 
     Args:
@@ -331,7 +331,7 @@ def test_get_user_by_verification(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_stream_casts(fcc: MerkleApiClient) -> None:
+def test_stream_casts(fcc: Warpcast) -> None:
     """Unit test that tests streaming casts
 
     Args:
@@ -350,7 +350,7 @@ def test_stream_casts(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_stream_casts_skip_existing(fcc: MerkleApiClient) -> None:
+def test_stream_casts_skip_existing(fcc: Warpcast) -> None:
     """Unit test that tests streaming casts
 
     Args:
@@ -365,7 +365,7 @@ def test_stream_casts_skip_existing(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_stream_users(fcc: MerkleApiClient) -> None:
+def test_stream_users(fcc: Warpcast) -> None:
     """Unit test that tests streaming users
 
     Args:
@@ -384,7 +384,7 @@ def test_stream_users(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_stream_users_skip_existing(fcc: MerkleApiClient) -> None:
+def test_stream_users_skip_existing(fcc: Warpcast) -> None:
     """Unit test that tests streaming users
 
     Args:
@@ -399,7 +399,7 @@ def test_stream_users_skip_existing(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_stream_notifications(fcc: MerkleApiClient) -> None:
+def test_stream_notifications(fcc: Warpcast) -> None:
     """Unit test that tests streaming notifications
 
     Args:
@@ -418,7 +418,7 @@ def test_stream_notifications(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_stream_notifications_skip_existing(fcc: MerkleApiClient) -> None:
+def test_stream_notifications_skip_existing(fcc: Warpcast) -> None:
     """Unit test that tests streaming notifications
 
     Args:
@@ -439,7 +439,7 @@ class TestRW:
 
     @pytest.mark.vcr
     @pytest.mark.dependency()
-    def test_post_cast(self, fcc: MerkleApiClient) -> None:
+    def test_post_cast(self, fcc: Warpcast) -> None:
         """Unit test that posts cast
 
         Args:
@@ -456,7 +456,7 @@ class TestRW:
 
     @pytest.mark.vcr
     @pytest.mark.dependency(depends=["TestRW::test_post_cast"])
-    def test_like_cast(self, fcc: MerkleApiClient) -> None:
+    def test_like_cast(self, fcc: Warpcast) -> None:
         """Unit test that puts cast likes
 
         Args:
@@ -471,7 +471,7 @@ class TestRW:
 
     @pytest.mark.vcr
     @pytest.mark.dependency(depends=["TestRW::test_like_cast"])
-    def test_delete_cast_likes(self, fcc: MerkleApiClient) -> None:
+    def test_delete_cast_likes(self, fcc: Warpcast) -> None:
         """Unit test that deletes cast likes
 
         Args:
@@ -486,7 +486,7 @@ class TestRW:
 
     @pytest.mark.vcr
     @pytest.mark.dependency(depends=["TestRW::test_post_cast"])
-    def test_recast(self, fcc: MerkleApiClient) -> None:
+    def test_recast(self, fcc: Warpcast) -> None:
         """Unit test that recasts cast
 
         Args:
@@ -500,7 +500,7 @@ class TestRW:
 
     @pytest.mark.vcr
     @pytest.mark.dependency(depends=["TestRW::test_recast"])
-    def test_delete_recast(self, fcc: MerkleApiClient) -> None:
+    def test_delete_recast(self, fcc: Warpcast) -> None:
         """Unit test that deletes recast
 
         Args:
@@ -516,7 +516,7 @@ class TestRW:
 
     @pytest.mark.vcr
     @pytest.mark.dependency(depends=["TestRW::test_post_cast"])
-    def test_delete_cast(self, fcc: MerkleApiClient) -> None:
+    def test_delete_cast(self, fcc: Warpcast) -> None:
         """Unit test that deletes cast
 
         Args:

--- a/tests/test_merkle.py
+++ b/tests/test_merkle.py
@@ -1,10 +1,10 @@
 import pytest
 
-from farcaster.client import MerkleApiClient
+from farcaster.client import Warpcast
 
 
 @pytest.mark.vcr
-def test_mention_reply_notifications(fcc: MerkleApiClient) -> None:
+def test_mention_reply_notifications(fcc: Warpcast) -> None:
     """Unit test that gets a user's recent notifications. Has to be the user who owns the access token
 
     Args:
@@ -18,7 +18,7 @@ def test_mention_reply_notifications(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_get_user_collections(fcc: MerkleApiClient) -> None:
+def test_get_user_collections(fcc: Warpcast) -> None:
     """Unit test that gets a user's collections
 
     Args:
@@ -32,7 +32,7 @@ def test_get_user_collections(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_get_collection_owners(fcc: MerkleApiClient) -> None:
+def test_get_collection_owners(fcc: Warpcast) -> None:
     """Unit test that gets a collection's owners
 
     Args:
@@ -46,7 +46,7 @@ def test_get_collection_owners(fcc: MerkleApiClient) -> None:
 
 
 @pytest.mark.vcr
-def test_get_healthcheck(fcc: MerkleApiClient) -> None:
+def test_get_healthcheck(fcc: Warpcast) -> None:
     """Unit test that gets healthcheck
 
     Args:

--- a/tests/test_merkle.py
+++ b/tests/test_merkle.py
@@ -4,56 +4,56 @@ from farcaster.client import Warpcast
 
 
 @pytest.mark.vcr
-def test_mention_reply_notifications(fcc: Warpcast) -> None:
+def test_mention_reply_notifications(client: Warpcast) -> None:
     """Unit test that gets a user's recent notifications. Has to be the user who owns the access token
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    response = fcc.get_mention_and_reply_notifications(limit=10)
+    response = client.get_mention_and_reply_notifications(limit=10)
     assert len(response.notifications) == 1
 
 
 @pytest.mark.vcr
-def test_get_user_collections(fcc: Warpcast) -> None:
+def test_get_user_collections(client: Warpcast) -> None:
     """Unit test that gets a user's collections
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    response = fcc.get_user_collections(owner_fid=50)
+    response = client.get_user_collections(owner_fid=50)
     assert len(response.collections) > 1
 
 
 @pytest.mark.vcr
-def test_get_collection_owners(fcc: Warpcast) -> None:
+def test_get_collection_owners(client: Warpcast) -> None:
     """Unit test that gets a collection's owners
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    response = fcc.get_collection_owners(collection_id="proof-of-merge")
+    response = client.get_collection_owners(collection_id="proof-of-merge")
     assert len(response.users) > 1
 
 
 @pytest.mark.vcr
-def test_get_healthcheck(fcc: Warpcast) -> None:
+def test_get_healthcheck(client: Warpcast) -> None:
     """Unit test that gets healthcheck
 
     Args:
-        fcc: fixture
+        client: fixture
 
     Returns:
         None
     """
-    response = fcc.get_healthcheck()
+    response = client.get_healthcheck()
     assert response


### PR DESCRIPTION
## Description

* Renaming the `MerkleApiClient` to `Warpcast`, in accordance with the Merkle rebrand of their client and API service
* Updating documentation to reflect the above change, and clarify difference between Warpcast and Farcaster
* Renaming `fcc` to `client` everywhere for clarity and consistency

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/a16z/farcaster-py/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/a16z/farcaster-py/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
