### PR TITLE
Include cursor in iterable result sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # farcaster-py
-a
+
 <div align="center">
 
 [![Build status](https://github.com/a16z/farcaster-py/workflows/build/badge.svg?branch=main&event=push)](https://github.com/a16z/farcaster-py/actions?query=workflow%3Abuild)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # farcaster-py
-
+a
 <div align="center">
 
 [![Build status](https://github.com/a16z/farcaster-py/workflows/build/badge.svg?branch=main&event=push)](https://github.com/a16z/farcaster-py/actions?query=workflow%3Abuild)

--- a/farcaster/client.py
+++ b/farcaster/client.py
@@ -221,7 +221,7 @@ class Warpcast:
         cast_hash: str,
         cursor: NoneStr = None,
         limit: PositiveInt = 25,
-    ) -> ReactionsResult:
+    ) -> IterableReactionsResult:
         """Get the likes for a given cast
 
         Args:
@@ -232,11 +232,15 @@ class Warpcast:
         Returns:
             ReactionsResult: ReactionsResult model of likes
         """
-        response = self._get(
-            "cast-likes",
-            params={"castHash": cast_hash, "cursor": cursor, "limit": limit},
+        response = CastReactionsGetResponse(
+            **self._get(
+                "cast-likes",
+                params={"castHash": cast_hash, "cursor": cursor, "limit": limit},
+            )
         )
-        return CastReactionsGetResponse(**response).result
+        return IterableReactionsResult(
+            likes=response.result.likes, cursor=response.next.cursor
+        )
 
     def like_cast(self, cast_hash: str) -> ReactionsPutResult:
         """Like a given cast
@@ -333,7 +337,7 @@ class Warpcast:
         fid: int,
         cursor: NoneStr = None,
         limit: PositiveInt = 25,
-    ) -> CastsResult:
+    ) -> IterableCastsResult:
         """Get the casts for a given fid of a user
 
         Args:
@@ -344,11 +348,15 @@ class Warpcast:
         Returns:
             CastsResult: Model containing the casts
         """
-        response = self._get(
-            "casts",
-            params={"fid": fid, "cursor": cursor, "limit": limit},
+        response = CastsGetResponse(
+            **self._get(
+                "casts",
+                params={"fid": fid, "cursor": cursor, "limit": limit},
+            )
         )
-        return CastsGetResponse(**response).result
+        return IterableCastsResult(
+            casts=response.result.casts, cursor=response.next.cursor
+        )
 
     def post_cast(
         self,
@@ -394,7 +402,7 @@ class Warpcast:
         collection_id: str,
         cursor: NoneStr = None,
         limit: PositiveInt = 25,
-    ) -> UsersResult:
+    ) -> IterableUsersResult:
         """Get the owners of an OpenSea collection
 
         Args:
@@ -405,18 +413,26 @@ class Warpcast:
         Returns:
             UsersResult: model containing users
         """
-        response = self._get(
-            "collection-owners",
-            params={"collectionId": collection_id, "cursor": cursor, "limit": limit},
+        response = CollectionOwnersGetResponse(
+            **self._get(
+                "collection-owners",
+                params={
+                    "collectionId": collection_id,
+                    "cursor": cursor,
+                    "limit": limit,
+                },
+            )
         )
-        return CollectionOwnersGetResponse(**response).result
+        return IterableUsersResult(
+            users=response.result.users, cursor=response.next.cursor
+        )
 
     def get_followers(
         self,
         fid: int,
         cursor: NoneStr = None,
         limit: PositiveInt = 25,
-    ) -> UsersResult:
+    ) -> IterableUsersResult:
         """Get the followers of a user
 
         Args:
@@ -427,18 +443,22 @@ class Warpcast:
         Returns:
             UsersResult: model containing users
         """
-        response = self._get(
-            "followers",
-            params={"fid": fid, "cursor": cursor, "limit": limit},
+        response = FollowersGetResponse(
+            **self._get(
+                "followers",
+                params={"fid": fid, "cursor": cursor, "limit": limit},
+            )
         )
-        return FollowersGetResponse(**response).result
+        return IterableUsersResult(
+            users=response.result.users, cursor=response.next.cursor
+        )
 
     def get_following(
         self,
         fid: int,
         cursor: NoneStr = None,
         limit: PositiveInt = 25,
-    ) -> UsersResult:
+    ) -> IterableUsersResult:
         """Get the users a user is following
 
         Args:
@@ -449,11 +469,15 @@ class Warpcast:
         Returns:
             UsersResult: model containing users
         """
-        response = self._get(
-            "following",
-            params={"fid": fid, "cursor": cursor, "limit": limit},
+        response = FollowingGetResponse(
+            **self._get(
+                "following",
+                params={"fid": fid, "cursor": cursor, "limit": limit},
+            )
         )
-        return FollowingGetResponse(**response).result
+        return IterableUsersResult(
+            users=response.result.users, cursor=response.next.cursor
+        )
 
     def get_all_following(self, fid: Optional[int] = None) -> UsersResult:
         """Get all the users a user is following by iterating through the next cursors
@@ -823,7 +847,7 @@ class Warpcast:
         self,
         cursor: NoneStr = None,
         limit: PositiveInt = 100,
-    ) -> CastsResult:
+    ) -> IterableCastsResult:
         """Get all recent casts
 
         Args:
@@ -833,11 +857,15 @@ class Warpcast:
         Returns:
             CastsResult: model containing casts
         """
-        response = self._get(
-            "recent-casts",
-            params={"cursor": cursor, "limit": limit},
+        response = CastsGetResponse(
+            **self._get(
+                "recent-casts",
+                params={"cursor": cursor, "limit": limit},
+            )
         )
-        return CastsGetResponse(**response).result
+        return IterableCastsResult(
+            casts=response.result.casts, cursor=response.next.cursor
+        )
 
     def _recent_casts_lists(
         self,

--- a/farcaster/client.py
+++ b/farcaster/client.py
@@ -167,7 +167,7 @@ class Warpcast:
         self,
         cursor: NoneStr = None,
         limit: PositiveInt = 25,
-    ) -> EventsResult:
+    ) -> IterableEventsResult:
         """Get events for a given asset
 
         Args:
@@ -176,13 +176,17 @@ class Warpcast:
                 to 25
 
         Returns:
-            EventsResult: Returns the EventsResult model
+            IterableEventsResult: Returns the EventsResult model with an optional cursor
         """
-        response = self._get(
-            "asset-events",
-            params={"cursor": cursor, "limit": limit},
+        response = AssetEventsGetResponse(
+            **self._get(
+                "asset-events",
+                params={"cursor": cursor, "limit": limit},
+            )
         )
-        return AssetEventsGetResponse(**response).result
+        return IterableEventsResult(
+            events=response.result.events, cursor=getattr(response.next, "cursor", None)
+        )
 
     def put_auth(self, auth_params: AuthParams) -> TokenResult:
         """Generate a custody bearer token and use it to generate an access token
@@ -230,7 +234,7 @@ class Warpcast:
             limit (PositiveInt, optional): limit, defaults to 25
 
         Returns:
-            ReactionsResult: ReactionsResult model of likes
+            IterableReactionsResult: Model containing the likes with an optional cursor
         """
         response = CastReactionsGetResponse(
             **self._get(
@@ -239,7 +243,7 @@ class Warpcast:
             )
         )
         return IterableReactionsResult(
-            likes=response.result.likes, cursor=response.next.cursor
+            likes=response.result.likes, cursor=getattr(response.next, "cursor", None)
         )
 
     def like_cast(self, cast_hash: str) -> ReactionsPutResult:
@@ -279,7 +283,7 @@ class Warpcast:
         cast_hash: str,
         cursor: NoneStr = None,
         limit: PositiveInt = 25,
-    ) -> UsersResult:
+    ) -> IterableUsersResult:
         """Get the recasters for a given cast
 
         Args:
@@ -288,13 +292,17 @@ class Warpcast:
             limit (PositiveInt, optional): limit, defaults to 25
 
         Returns:
-            UsersResult: Model containing the recasters
+            IterableUsersResult: Model containing the recasters with an optional cursor
         """
-        response = self._get(
-            "cast-recasters",
-            params={"castHash": cast_hash, "cursor": cursor, "limit": limit},
+        response = CastRecastersGetResponse(
+            **self._get(
+                "cast-recasters",
+                params={"castHash": cast_hash, "cursor": cursor, "limit": limit},
+            )
         )
-        return CastRecastersGetResponse(**response).result
+        return IterableUsersResult(
+            users=response.result.users, cursor=getattr(response.next, "cursor", None)
+        )
 
     def get_cast(
         self,
@@ -346,7 +354,7 @@ class Warpcast:
             limit (PositiveInt, optional): limit, defaults to 25
 
         Returns:
-            CastsResult: Model containing the casts
+            IterableCastsResult: Model containing the casts with an optional cursor
         """
         response = CastsGetResponse(
             **self._get(
@@ -355,7 +363,7 @@ class Warpcast:
             )
         )
         return IterableCastsResult(
-            casts=response.result.casts, cursor=response.next.cursor
+            casts=response.result.casts, cursor=getattr(response.next, "cursor", None)
         )
 
     def post_cast(
@@ -411,7 +419,7 @@ class Warpcast:
             limit (PositiveInt, optional): limit, defaults to 25
 
         Returns:
-            UsersResult: model containing users
+            IterableUsersResult: model containing users with an optional cursor
         """
         response = CollectionOwnersGetResponse(
             **self._get(
@@ -424,7 +432,7 @@ class Warpcast:
             )
         )
         return IterableUsersResult(
-            users=response.result.users, cursor=response.next.cursor
+            users=response.result.users, cursor=getattr(response.next, "cursor", None)
         )
 
     def get_followers(
@@ -441,7 +449,7 @@ class Warpcast:
             limit (PositiveInt, optional): limit, defaults to 25
 
         Returns:
-            UsersResult: model containing users
+            IterableUsersResult: model containing users with an optional cursor
         """
         response = FollowersGetResponse(
             **self._get(
@@ -450,7 +458,7 @@ class Warpcast:
             )
         )
         return IterableUsersResult(
-            users=response.result.users, cursor=response.next.cursor
+            users=response.result.users, cursor=getattr(response.next, "cursor", None)
         )
 
     def get_following(
@@ -467,7 +475,7 @@ class Warpcast:
             limit (PositiveInt, optional): limit, defaults to 25
 
         Returns:
-            UsersResult: model containing users
+            IterableUsersResult: model containing users with an optional cursor
         """
         response = FollowingGetResponse(
             **self._get(
@@ -476,7 +484,7 @@ class Warpcast:
             )
         )
         return IterableUsersResult(
-            users=response.result.users, cursor=response.next.cursor
+            users=response.result.users, cursor=getattr(response.next, "cursor", None)
         )
 
     def get_all_following(self, fid: Optional[int] = None) -> UsersResult:
@@ -555,7 +563,7 @@ class Warpcast:
         self,
         cursor: NoneStr = None,
         limit: PositiveInt = 25,
-    ) -> NotificationsResult:
+    ) -> IterableNotificationsResult:
         """Get mention and reply notifications
 
         Args:
@@ -563,13 +571,18 @@ class Warpcast:
             limit (PositiveInt, optional): limit, defaults to 25
 
         Returns:
-            NotificationsResult: model containing notifications
+            IterableNotificationsResult: model containing notifications with an optional cursor
         """
-        response = self._get(
-            "mention-and-reply-notifications",
-            params={"cursor": cursor, "limit": limit},
+        response = MentionAndReplyNotificationsGetResponse(
+            **self._get(
+                "mention-and-reply-notifications",
+                params={"cursor": cursor, "limit": limit},
+            )
         )
-        return MentionAndReplyNotificationsGetResponse(**response).result
+        return IterableNotificationsResult(
+            notifications=response.result.notifications,
+            cursor=getattr(response.next, "cursor", None),
+        )
 
     def _recent_notifications_list(
         self,
@@ -702,7 +715,7 @@ class Warpcast:
         owner_fid: int,
         cursor: NoneStr = None,
         limit: PositiveInt = 25,
-    ) -> CollectionsResult:
+    ) -> IterableCollectionsResult:
         """Get the collections of a user
 
         Args:
@@ -711,20 +724,25 @@ class Warpcast:
             limit (PositiveInt, optional): limit, defaults to 25
 
         Returns:
-            CollectionsResult: model containing collections
+            IterableCollectionsResult: model containing collections with an optional cursor
         """
-        response = self._get(
-            "user-collections",
-            params={"ownerFid": owner_fid, "cursor": cursor, "limit": limit},
+        response = UserCollectionsGetResponse(
+            **self._get(
+                "user-collections",
+                params={"ownerFid": owner_fid, "cursor": cursor, "limit": limit},
+            )
         )
-        return UserCollectionsGetResponse(**response).result
+        return IterableCollectionsResult(
+            collections=response.result.collections,
+            cursor=getattr(response.next, "cursor", None),
+        )
 
     def get_verifications(
         self,
         fid: int,
         cursor: NoneStr = None,
         limit: PositiveInt = 25,
-    ) -> VerificationsResult:
+    ) -> IterableVerificationsResult:
         """Get the verifications of a user
 
         Args:
@@ -733,19 +751,24 @@ class Warpcast:
             limit (PositiveInt, optional): limit, defaults to 25
 
         Returns:
-            VerificationsResult: model containing verifications
+            IterableVerificationsResult: model containing verifications with an optional cursor
         """
-        response = self._get(
-            "verifications",
-            params={"fid": fid, "cursor": cursor, "limit": limit},
+        response = VerificationsGetResponse(
+            **self._get(
+                "verifications",
+                params={"fid": fid, "cursor": cursor, "limit": limit},
+            )
         )
-        return VerificationsGetResponse(**response).result
+        return IterableVerificationsResult(
+            verifications=response.result.verifications,
+            cursor=getattr(response.next, "cursor", None),
+        )
 
     def get_recent_users(
         self,
         cursor: NoneStr = None,
         limit: PositiveInt = 25,
-    ) -> UsersResult:
+    ) -> IterableUsersResult:
         """Get recent users
 
         Args:
@@ -753,13 +776,17 @@ class Warpcast:
             limit (PositiveInt, optional): limit, defaults to 25
 
         Returns:
-            UsersResult: model containing users
+            IterableUsersResult: model containing users with an optional cursor
         """
-        response = self._get(
-            "recent-users",
-            params={"cursor": cursor, "limit": limit},
+        response = UsersGetResponse(
+            **self._get(
+                "recent-users",
+                params={"cursor": cursor, "limit": limit},
+            )
         )
-        return UsersGetResponse(**response).result
+        return IterableUsersResult(
+            users=response.result.users, cursor=getattr(response.next, "cursor", None)
+        )
 
     def _recent_users_list(
         self,
@@ -826,7 +853,7 @@ class Warpcast:
         fid: int,
         cursor: NoneStr = None,
         limit: PositiveInt = 25,
-    ) -> Likes:
+    ) -> IterableLikes:
         """Get the likes of a user
 
         Args:
@@ -835,13 +862,17 @@ class Warpcast:
             limit (PositiveInt, optional): limit, defaults to 25
 
         Returns:
-            Likes: model containing likes
+            IterableLikes: model containing likes with an optional cursor
         """
-        response = self._get(
-            "user-cast-likes",
-            params={"fid": fid, "cursor": cursor, "limit": limit},
+        response = UserCastLikesGetResponse(
+            **self._get(
+                "user-cast-likes",
+                params={"fid": fid, "cursor": cursor, "limit": limit},
+            )
         )
-        return UserCastLikesGetResponse(**response).result
+        return IterableLikes(
+            likes=response.result.likes, cursor=getattr(response.next, "cursor", None)
+        )
 
     def get_recent_casts(
         self,
@@ -855,7 +886,7 @@ class Warpcast:
             limit (PositiveInt, optional): limit, defaults to 100
 
         Returns:
-            CastsResult: model containing casts
+            IterableCastsResult: model containing casts with an optional cursor
         """
         response = CastsGetResponse(
             **self._get(
@@ -864,7 +895,7 @@ class Warpcast:
             )
         )
         return IterableCastsResult(
-            casts=response.result.casts, cursor=response.next.cursor
+            casts=response.result.casts, cursor=getattr(response.next, "cursor", None)
         )
 
     def _recent_casts_lists(

--- a/farcaster/models.py
+++ b/farcaster/models.py
@@ -454,6 +454,11 @@ class EventsResult(BaseModel):
     events: List[ApiAssetEvent]
 
 
+class IterableEventsResult(BaseModel):
+    events: List[ApiAssetEvent]
+    cursor: NoneStr = None
+
+
 class AssetEventsGetResponse(BaseModel):
     result: EventsResult
     next: Optional[Next] = None
@@ -504,7 +509,7 @@ class CastsResult(BaseModel):
 
 class IterableCastsResult(BaseModel):
     casts: List[ApiCast]
-    cursor: Optional[str] = None
+    cursor: NoneStr = None
 
 
 class CastsGetResponse(BaseModel):
@@ -541,7 +546,7 @@ class ReactionsResult(BaseModel):
 
 class IterableReactionsResult(BaseModel):
     likes: List[ApiCastReaction]
-    cursor: Optional[str] = None
+    cursor: NoneStr = None
 
 
 class ReactionsPutResult(BaseModel):
@@ -575,7 +580,7 @@ class UsersResult(BaseModel):
 
 class IterableUsersResult(BaseModel):
     users: List[ApiUser]
-    cursor: Optional[str] = None
+    cursor: NoneStr = None
 
 
 class CastRecastersGetResponse(BaseModel):
@@ -585,6 +590,11 @@ class CastRecastersGetResponse(BaseModel):
 
 class CollectionsResult(BaseModel):
     collections: List[ApiAssetCollection]
+
+
+class IterableCollectionsResult(BaseModel):
+    collections: List[ApiAssetCollection]
+    cursor: NoneStr = None
 
 
 class UserCollectionsGetResponse(BaseModel):
@@ -623,6 +633,11 @@ class CustodyAddressGetResponse(BaseModel):
 
 class Likes(BaseModel):
     likes: List[ApiCastReaction]
+
+
+class IterableLikes(BaseModel):
+    likes: List[ApiCastReaction]
+    cursor: NoneStr = None
 
 
 class UserCastLikesGetResponse(BaseModel):
@@ -673,6 +688,11 @@ class NotificationsResult(BaseModel):
     notifications: List[Union[MentionNotification, ReplyNotification]]
 
 
+class IterableNotificationsResult(BaseModel):
+    notifications: List[Union[MentionNotification, ReplyNotification]]
+    cursor: NoneStr = None
+
+
 class MentionAndReplyNotificationsGetResponse(BaseModel):
     result: NotificationsResult
     next: Optional[Next] = None
@@ -692,6 +712,11 @@ class UserByUsernameGetResponse(BaseModel):
 
 class VerificationsResult(BaseModel):
     verifications: List[ApiVerification]
+
+
+class IterableVerificationsResult(BaseModel):
+    verifications: List[ApiVerification]
+    cursor: NoneStr = None
 
 
 class VerificationsGetResponse(BaseModel):

--- a/farcaster/models.py
+++ b/farcaster/models.py
@@ -502,6 +502,11 @@ class CastsResult(BaseModel):
     casts: List[ApiCast]
 
 
+class IterableCastsResult(BaseModel):
+    casts: List[ApiCast]
+    cursor: Optional[str] = None
+
+
 class CastsGetResponse(BaseModel):
     result: CastsResult
     next: Optional[Next] = None
@@ -534,6 +539,11 @@ class ReactionsResult(BaseModel):
     likes: List[ApiCastReaction]
 
 
+class IterableReactionsResult(BaseModel):
+    likes: List[ApiCastReaction]
+    cursor: Optional[str] = None
+
+
 class ReactionsPutResult(BaseModel):
     like: ApiCastReaction
 
@@ -561,6 +571,11 @@ class CastReactionsDeleteRequest(BaseModel):
 
 class UsersResult(BaseModel):
     users: List[ApiUser]
+
+
+class IterableUsersResult(BaseModel):
+    users: List[ApiUser]
+    cursor: Optional[str] = None
 
 
 class CastRecastersGetResponse(BaseModel):


### PR DESCRIPTION
## Description

Creates an iterable result object that adds a cursor alongside a typical response list. This new object is a transformation of the Warpcast API response, so it must be intentionally built.

The iterable result object is added in such a way to prevent any breaking API changes.

## Related Issue

Fixes #251

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/a16z/farcaster-py/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/a16z/farcaster-py/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
