### PR TITLE
fix: remove unused github secret from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,6 @@ jobs:
 
       - name: Run tests
         env:
-          AUTH: ${{ secrets.AUTH }}
+          AUTH: "foobar"
         run: |
           make test-ci


### PR DESCRIPTION
## Description

We don't need any secrets for the default build CI. Having a dependency on it is causing fork PRs to fail.

## Type of Change

Remove unused secret from CI workflow.

- [x] 🔧 Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/a16z/farcaster-py/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/a16z/farcaster-py/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
