### PR TITLE
Add missing parsimonious dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ pyhumps = "^3.7.2"
 requests = "^2.28.1"
 canonicaljson = "^1.6.4"
 eth-account = "^0.8.0"
+parsimonious = "^0.8.1"
 
 [tool.poetry.group.dev.dependencies]
 bandit = "^1.7.1"


### PR DESCRIPTION
## Description

The dependency is missing when packaging. It is well defined for Poetry and Pip, but not pyproject.toml. This commit adds the dependency with the same version requirements as in the Poetry spec.

I hit the issue when playing with the new `farcaster-cli` 0.1.3 and 0.1.4. Installation works fine, but run crashes for missing `parsimonious`. This dependency belongs to `farcaster-py` and missing from the packaging code (`pyrpoject.toml`), so proposing a change here.

Notes:
* I followed the contribution guideline, but also run the test suite. It fails because some `AUTH` is needed, so submitting PR without the test suite.
* On the other hand, I created a wheel and installed it in a blank environment. That worked fine then.
* The project is using Poetry and pyproject. It seems the origin of the problem is some drift here. Not sure how to avoid in the future. If using GitHub CI workflow, perhaps good to test packaging too, but forcing a blank environment each run to detect drift.

## Related Issue

None

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [X] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [X] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/a16z/farcaster-py/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I've read the [`CONTRIBUTING.md`](https://github.com/a16z/farcaster-py/blob/master/CONTRIBUTING.md) guide.
- [X] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
