### PR TITLE
Adding ability to cast to channels

### DIFF
--- a/farcaster/client.py
+++ b/farcaster/client.py
@@ -409,7 +409,9 @@ class Warpcast:
         Returns:
             CastContent: The result of posting the cast
         """
-        body = CastsPostRequest(text=text, embeds=embeds, parent=parent, channel_key=channel_key)
+        body = CastsPostRequest(
+            text=text, embeds=embeds, parent=parent, channel_key=channel_key
+        )
         response = self._post(
             "casts",
             json=body.model_dump(by_alias=True, exclude_none=True),

--- a/farcaster/client.py
+++ b/farcaster/client.py
@@ -396,6 +396,7 @@ class Warpcast:
         text: str,
         embeds: Optional[List[str]] = None,
         parent: Optional[Parent] = None,
+        channel_key: Optional[str] = None,
     ) -> CastContent:
         """Post a cast to Farcaster
 
@@ -403,11 +404,12 @@ class Warpcast:
             text (str): text of the cast
             embeds (Optional[List[str]], optional): list of embeds, defaults to None
             parent (Optional[Parent], optional): parent of the cast, defaults to None
+            channel_key (Optional[str], optional): channel of the cast, defaults to None
 
         Returns:
             CastContent: The result of posting the cast
         """
-        body = CastsPostRequest(text=text, embeds=embeds, parent=parent)
+        body = CastsPostRequest(text=text, embeds=embeds, parent=parent, channel_key=channel_key)
         response = self._post(
             "casts",
             json=body.model_dump(by_alias=True, exclude_none=True),

--- a/farcaster/models.py
+++ b/farcaster/models.py
@@ -564,6 +564,7 @@ class CastsPostRequest(BaseModel):
     text: str
     embeds: Optional[List[str]] = None
     parent: Optional[Parent] = None
+    channel_key: Optional[str] = None
 
 
 class CastsPostResponse(BaseModel):


### PR DESCRIPTION
## Description

Added `channel_key` to `post_cast` so that casts can be posted to channels. 

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/a16z/farcaster-py/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/a16z/farcaster-py/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
